### PR TITLE
Updated elgohr/Github-Release-Action to a supported version (v4)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Create a Release
-      uses: elgohr/Github-Release-Action@master
+      uses: elgohr/Github-Release-Action@v4
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_USER: havogt


### PR DESCRIPTION
elgohr/Github-Release-Action@master is not supported anymore